### PR TITLE
Being able to select a detached head commit in the grid

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -345,7 +345,7 @@ namespace GitCommands
         /// <summary>"(no branch)"</summary>
         public static readonly string DetachedBranch = "(no branch)";
 
-        private static readonly string[] DetachedPrefixes = { "(no branch", "(detached from " };
+        private static readonly string[] DetachedPrefixes = { "(no branch", "(detached from ", "(HEAD detached at " };
 
         public AppSettings.PullAction LastPullAction
         {

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2542,6 +2542,24 @@ namespace GitCommands
             return DetachedPrefixes.Any(a => branch.StartsWith(a, StringComparison.Ordinal));
         }
 
+        private static Regex detachedHeadRegex = new Regex(@"^\(.* (?<sha1>.*)\)$");
+
+        public static bool TryParseDetachedHead(string text, out string sha1)
+        {
+            sha1 = null;
+            if (IsDetachedHead(text))
+                return false;
+
+            var sha1Match = detachedHeadRegex.Match(text);
+            if (!sha1Match.Success)
+            {
+                return false;
+            }
+
+            sha1 = sha1Match.Groups["sha1"].Value;
+            return true;
+        }
+
         /// <summary>Gets the remote of the current branch; or "origin" if no remote is configured.</summary>
         public string GetCurrentRemote()
         {

--- a/GitExtensionsTest/GitCommands/Git/GitCommandHelpersTest.cs
+++ b/GitExtensionsTest/GitCommands/Git/GitCommandHelpersTest.cs
@@ -212,5 +212,21 @@ namespace GitExtensionsTest.Git
             outUrl = GitCommandHelpers.GetPlinkCompatibleUrl(inUrl);
             Assert.AreEqual("\"" + inUrl + "\"", outUrl);
         }
+
+        [TestMethod]
+        public void ShouldExtractOldVersionOfDetachedHeadOutput()
+        {
+            string sha1;
+            Assert.True(GitModule.TryParseDetachedHead("(detached from c299581)", out sha1));
+            Assert.AreEqual("c299581", sha1);
+        }
+
+        [TestMethod]
+        public void ShouldExtractNewVersionOfDetachedHeadOutput()
+        {
+            string sha1;
+            Assert.True(GitModule.TryParseDetachedHead("(HEAD detached at c299582)", out sha1));
+            Assert.AreEqual("c299582", sha1);
+        }
     }
 }

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -3020,6 +3020,12 @@ namespace GitUI
 
         public void GoToRef(string refName, bool showNoRevisionMsg)
         {
+            string sha1;
+            if (GitModule.TryParseDetachedHead(refName, out sha1))
+            {
+                refName = sha1;
+            }
+
             string revisionGuid = Module.RevParse(refName);
             if (!string.IsNullOrEmpty(revisionGuid))
             {


### PR DESCRIPTION
When we are in a detached head state,
the `git branch` command output "(HEAD detached at c299581)"
and the sha1 should be extracted to be able to select the good revision
instead of getting the ugly popup "no revision found!"

Way to reproduce:
Checkout a specific revision and use the left panel
in selecting/unselecting this "branch"
